### PR TITLE
#3: clean sass (closes #3)

### DIFF
--- a/src/FlexView.js
+++ b/src/FlexView.js
@@ -168,7 +168,7 @@ export default class FlexView extends React.Component {
   };
 
   getClasses = () => {
-    const direction = this.props.column ? 'flex-column' : 'flex-row';
+    const direction = this.props.column && 'flex-column';
     const contentAlignment = this.getContentAlignmentClasses();
     const wrap = this.props.wrap && 'flex-wrap';
     return cx('react-flex-view', direction, contentAlignment, wrap, this.props.className);

--- a/src/flexView.scss
+++ b/src/flexView.scss
@@ -6,15 +6,12 @@
   min-width: 0;
   min-height: 0;
   @include display_flex();
+  @include flex_flex-direction(row);
   @include flex_flex-wrap(nowrap);
   @include flex_align-items(stretch);
 
   &.flex-column {
     @include flex_flex-direction(column);
-  }
-
-  &.flex-row {
-    @include flex_flex-direction(row);
   }
 
   &.flex-wrap {

--- a/src/flexView.scss
+++ b/src/flexView.scss
@@ -9,10 +9,6 @@
   @include flex_flex-wrap(nowrap);
   @include flex_align-items(stretch);
 
-  &.flex-vertically-centered {
-    @include flex_align-items(center);
-  }
-
   &.flex-column {
     @include flex_flex-direction(column);
   }
@@ -21,12 +17,8 @@
     @include flex_flex-direction(row);
   }
 
-  &.flex-auto {
-    @include flex_flex(0 0 auto);
-  }
-
-  &.flex-grow {
-    @include flex_flex(1 1 100%);
+  &.flex-wrap {
+    @include flex_flex-wrap(wrap);
   }
 
   // ALIGN CONTENT
@@ -55,13 +47,4 @@
     @include flex_justify-content(flex-end);
   }
 
-  &.flex-wrap {
-    @include flex_flex-wrap(wrap);
-  }
-
-}
-
-.react-flex-view.react-flex-cell {
-  @include flex_justify-content(space-between);
-  @include flex_align-content(space-between);
 }


### PR DESCRIPTION
Issue #3

## Test Plan

### tests performed
- selectors removed from first commit were not used in javascript
- if `column={true}` -> `flex-direction: column`
- else -> `flex-direction: row`
- tested some random props configurations with `ComputeFlex` example