### PR TITLE
#6: should import `tcomb` from `tcomb-react` (closes #6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "classnames": "^2.2.5",
     "lodash": "^4.15.0",
     "sass-flex-mixins": "^0.1.0",
-    "tcomb": "^3.2.13",
     "tcomb-react": "^0.9.3"
   },
   "devDependencies": {

--- a/src/FlexView.js
+++ b/src/FlexView.js
@@ -2,8 +2,7 @@ import React from 'react';
 import cx from 'classnames';
 import pick from 'lodash/pick';
 import omit from 'lodash/omit';
-import t from 'tcomb';
-import { props } from 'tcomb-react';
+import { t, props } from 'tcomb-react';
 
 
 export const Props = {


### PR DESCRIPTION
Issue #6

## Test Plan

### tests performed
-`rm -rf node_modules && npm i && npm start`
  - examples start and work correctly
- in brc try fixing the code to import `t` from `tcomb-react`
  - app starts and work correctly (so this fix should be effective)

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
