### PR TITLE
#15: add Flow/TypeScript support (closes #15)

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,10 @@
+[include]
+
+[ignore]
+<PROJECT_ROOT>/node_modules/fbjs
+<PROJECT_ROOT>/node_modules/react-addons-test-utils/node_modules/fbjs
+
+[libs]
+
+[options]
+esproposal.decorators=ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 coverage
 npm-debug.log
-lib
 **/.tags
 **/.tags1
+flow-typed/npm
+lib

--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,0 @@
-node_modules
-coverage
-npm-debug.log
-.git
-test
-karma*
-.eslintrc

--- a/flow-typed/buildo.js
+++ b/flow-typed/buildo.js
@@ -1,0 +1,11 @@
+type Many<T> = T | T[];
+
+declare module 'lodash/omit' {
+  declare function omit(object: Object, ...props: Array<Many<$Subtype<string>>>): Object;
+  declare var exports: typeof omit;
+}
+
+declare module 'lodash/pick' {
+  declare function pick(object: Object, ...props: Array<Many<$Subtype<string>>>): Object;
+  declare var exports: typeof pick;
+}

--- a/flow-typed/npm/classnames_v2.x.x.js
+++ b/flow-typed/npm/classnames_v2.x.x.js
@@ -1,0 +1,16 @@
+// flow-typed signature: cf6332fcf9a3398cffb131f7da90662b
+// flow-typed version: dc0ded3d57/classnames_v2.x.x/flow_>=v0.28.x
+
+type $npm$classnames$Classes =
+  string |
+  {[className: string]: ?boolean } |
+  Array<string> |
+  false |
+  void |
+  null
+
+declare module 'classnames' {
+  declare function exports(
+    ...classes: Array<$npm$classnames$Classes>
+  ): string;
+}

--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-module.exports = require('./lib');

--- a/package.json
+++ b/package.json
@@ -2,10 +2,16 @@
   "name": "react-flexview",
   "version": "1.0.1",
   "description": "A react component to abstract over flexbox",
-  "main": "index.js",
+  "files": [
+    "lib",
+    "src",
+    "react-flexview.d.ts"
+  ],
+  "main": "lib/index.js",
+  "typings": "react-flexview.d.ts",
   "scripts": {
     "test": "mocha",
-    "build": "rm -rf lib && mkdir lib && node-sass src --importer sass-importer.js --include-path node_modules -o lib && babel src -d lib",
+    "build": "rm -rf lib && mkdir lib && node-sass src --importer sass-importer.js --include-path node_modules -o lib && babel src -d lib && flow-copy-source -v src lib",
     "lint": "eslint src dev/examples.js dev/examples",
     "preversion": "npm run lint && npm run test && npm run build-examples",
     "postversion": "git push && git push --tags",
@@ -57,6 +63,8 @@
     "eslint-loader": "^1.3.0",
     "estraverse-fb": "^1.3.1",
     "extract-text-webpack-plugin": "^1.0.1",
+    "flow-bin": "^0.38.0",
+    "flow-copy-source": "^1.1.0",
     "html-webpack-plugin": "^1.7.0",
     "mocha": "^3.0.2",
     "node-sass": "^3.7.0",

--- a/react-flexview.d.ts
+++ b/react-flexview.d.ts
@@ -1,0 +1,50 @@
+/// <reference types="react" />
+import * as React from 'react';
+export declare type IProps = {
+    children?: any;
+    column?: boolean;
+    vAlignContent?: 'top' | 'center' | 'bottom';
+    hAlignContent?: 'left' | 'center' | 'right';
+    marginLeft?: string | number;
+    marginTop?: string | number;
+    marginRight?: string | number;
+    marginBottom?: string | number;
+    grow?: boolean | number;
+    shrink?: boolean | number;
+    basis?: string | number;
+    wrap?: boolean;
+    height?: string | number;
+    width?: string | number;
+    className?: string;
+    style?: {
+        [key: string]: any;
+    };
+};
+/** React component to abstract over flexbox
+ * @param children - flexView content
+ * @param column - flex-direction: column
+ * @param vAlignContent - align content vertically
+ * @param hAlignContent - align content horizontally
+ * @param marginLeft - margin-left property ("auto" to align self right)
+ * @param marginTop - margin-top property ("auto" to align self bottom)
+ * @param marginRight - margin-right property ("auto" to align self left)
+ * @param marginBottom - margin-bottom property ("auto" to align self top)
+ * @param grow property (for parent primary axis)
+ * @param shrink - flex-shrink property
+ * @param basis - flex-basis property
+ * @param wrap - wrap content
+ * @param height - height property (for parent secondary axis)
+ * @param width - width property (for parent secondary axis)
+ */
+export default class FlexView extends React.Component<IProps, void> {
+    componentDidMount(): void;
+    private logWarnings;
+    private getGrow;
+    private getShrink;
+    private getBasis;
+    private getFlexStyle;
+    private getStyle;
+    private getContentAlignmentClasses;
+    private getClasses;
+    render(): JSX.Element;
+}

--- a/src/FlexView.js
+++ b/src/FlexView.js
@@ -1,9 +1,29 @@
+// @flow
+
 import React from 'react';
 import cx from 'classnames';
 import pick from 'lodash/pick';
 import omit from 'lodash/omit';
 import { t, props } from 'tcomb-react';
 
+export type IProps = {
+  children?: any,
+  column?: boolean,
+  vAlignContent?: 'top' | 'center' | 'bottom',
+  hAlignContent?: 'left' | 'center' | 'right',
+  marginLeft?: string | number,
+  marginTop?: string | number,
+  marginRight?: string | number,
+  marginBottom?: string | number,
+  grow?: boolean | number,
+  shrink?: boolean | number,
+  basis?: string | number,
+  wrap?: boolean,
+  height?: string | number,
+  width?: string | number,
+  className?: string,
+  style?: Object
+};
 
 export const Props = {
   children: t.ReactChildren,
@@ -41,7 +61,7 @@ export const Props = {
  * @param width - width property (for parent secondary axis)
  */
 @props(Props, { strict: false })
-export default class FlexView extends React.Component {
+export default class FlexView extends React.Component<void, IProps, void> {
 
   componentDidMount() {
     this.logWarnings();
@@ -123,13 +143,13 @@ export default class FlexView extends React.Component {
     const vPrefix = this.props.column ? 'justify-content-' : 'align-content-';
     const hPrefix = this.props.column ? 'align-content-' : 'justify-content-';
 
-    const vAlignContentClasses = {
+    const vAlignContentClasses: Object = {
       top: `${vPrefix}start`,
       center: `${vPrefix}center`,
       bottom: `${vPrefix}end`
     };
 
-    const hAlignContentClasses = {
+    const hAlignContentClasses: Object = {
       left: `${hPrefix}start`,
       center: `${hPrefix}center`,
       right: `${hPrefix}end`
@@ -153,7 +173,7 @@ export default class FlexView extends React.Component {
     const style = this.getStyle();
     const props = omit(this.props, Object.keys(Props));
     return (
-      <div className={className} style={style} { ...props }>
+      <div className={className} style={style} {...props}>
         {this.props.children}
       </div>
     );

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,3 @@
-export default from './FlexView';
+// @flow
+import FlexView from './FlexView';
+export default FlexView;


### PR DESCRIPTION
Proof of concept

This PR adds:
- for consumers
  - Flow and TypeScript typings, shipped with the npm package itself
- for developers
  - source code ready for Flow (typings of dependencies that are needed are included)