### PR TITLE
#13: should not bind `this` when it's not necessary (closes #13)

### DIFF
--- a/src/FlexView.js
+++ b/src/FlexView.js
@@ -47,15 +47,15 @@ export default class FlexView extends React.Component {
     this.logWarnings();
   }
 
-  logWarnings = () => {
+  logWarnings() {
     if (process.env.NODE_ENV !== 'production' && this.props.basis === 'auto') {
       console.warn( // eslint-disable-line no-console
         'basis is "auto" by default: forcing it to "auto"  will leave "shrink:true" as default'
       );
     }
-  };
+  }
 
-  getGrow = () => {
+  getGrow() {
     const { grow } = this.props;
     if (typeof grow === 'number') {
       return grow;
@@ -64,9 +64,9 @@ export default class FlexView extends React.Component {
     }
 
     return 0; // default
-  };
+  }
 
-  getShrink = () => {
+  getShrink() {
     const { shrink, basis } = this.props;
     if (typeof shrink === 'number') {
       return shrink;
@@ -81,9 +81,9 @@ export default class FlexView extends React.Component {
     }
 
     return 1; // default
-  };
+  }
 
-  getBasis = () => {
+  getBasis() {
     const { basis } = this.props;
     if (basis) {
       const suffix = t.Number.is(basis) || String(parseInt(basis, 10)) === basis ? 'px' : '';
@@ -91,9 +91,9 @@ export default class FlexView extends React.Component {
     }
 
     return 'auto'; // default
-  };
+  }
 
-  getFlexStyle = () => {
+  getFlexStyle() {
     const grow = this.getGrow();
     const shrink = this.getShrink();
     const basis = this.getBasis();
@@ -105,9 +105,9 @@ export default class FlexView extends React.Component {
       WebkitFlex: values,
       flex: values
     };
-  };
+  }
 
-  getStyle = () => {
+  getStyle() {
     const style = pick(this.props, [
       'width',
       'height',
@@ -117,9 +117,9 @@ export default class FlexView extends React.Component {
       'marginBottom'
     ]);
     return { ...this.getFlexStyle(), ...style, ...this.props.style };
-  };
+  }
 
-  getContentAlignmentClasses = () => {
+  getContentAlignmentClasses() {
     const vPrefix = this.props.column ? 'justify-content-' : 'align-content-';
     const hPrefix = this.props.column ? 'align-content-' : 'justify-content-';
 
@@ -139,14 +139,14 @@ export default class FlexView extends React.Component {
     const hAlignContent = hAlignContentClasses[this.props.hAlignContent];
 
     return cx(vAlignContent, hAlignContent);
-  };
+  }
 
-  getClasses = () => {
+  getClasses() {
     const direction = this.props.column && 'flex-column';
     const contentAlignment = this.getContentAlignmentClasses();
     const wrap = this.props.wrap && 'flex-wrap';
     return cx('react-flex-view', direction, contentAlignment, wrap, this.props.className);
-  };
+  }
 
   render() {
     const className = this.getClasses();

--- a/src/FlexView.js
+++ b/src/FlexView.js
@@ -153,7 +153,7 @@ export default class FlexView extends React.Component {
     const style = this.getStyle();
     const props = omit(this.props, Object.keys(Props));
     return (
-      <div className={className} style={style} { ...props }>
+      <div className={className} style={style} {...props}>
         {this.props.children}
       </div>
     );


### PR DESCRIPTION
Issue #13

## Test Plan

### tests performed
instantiate old FlexView and new FlexView 10000 times and profile it with Chrome's timeline:

![image](https://cloud.githubusercontent.com/assets/4029499/22741515/c5bfbb66-ee13-11e6-8865-9e7d1d793a89.png)

The first spike is represented by the new FlexViews.
The second spike are the old FlexViews.

As you can see:
- JS time is ~5 times faster (in IE11 about 1.5-2 times faster). In absolute the difference is **irrelevant** (10000 instances -> ~30 ms with old `FlexView`)
- The needed Memory is much lower in new `FlexView` in both IE11 (went from ~3.8mb to 0.85mb) and Chrome (look at the blue line, you can clearly see a spike after the old `FlexView`s are instantiated)


PS: This fix will definitely not cause any relevant gain in performances, but IMO this PR is mergeable also as a simple code-clean (and perfs will definitely not go down)

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
