### PR TITLE
#23: FlexView logs warning when not needed (closes #23)

### DIFF
--- a/src/FlexView.js
+++ b/src/FlexView.js
@@ -81,8 +81,8 @@ export default class FlexView extends React.Component<void, IProps, void> {
     }
 
     if (
-      shrink === false || shrink === 0 &&
-      grow === true || (typeof grow === 'number' && grow > 0)
+      (shrink === false || shrink === 0) &&
+      (grow === true || (typeof grow === 'number' && grow > 0))
     ) {
       warn('passing both "grow" and "shrink={false}" is a no-op!');
     }


### PR DESCRIPTION
Closes #23

## Test Plan

### tests performed
- pass grow -> no warning
- pass shrink={false} -> no warning
- pass both grow and shrink={false} -> warning

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
