### PR TITLE
#37: Typescript: Props should be strict (closes #37)

### DIFF
--- a/react-flexview.d.ts
+++ b/react-flexview.d.ts
@@ -19,6 +19,7 @@ export declare interface IProps extends Pick<React.HTMLProps<HTMLDivElement>, HT
   wrap?: boolean;
   height?: string | number;
   width?: string | number;
+  ref?: string | ((instance: HTMLDivElement) => any);
 }
 /** React component to abstract over flexbox
  * @param children - flexView content

--- a/react-flexview.d.ts
+++ b/react-flexview.d.ts
@@ -1,26 +1,25 @@
 /// <reference types="react" />
 import * as React from 'react';
-export declare type IProps = {
-    children?: any;
-    column?: boolean;
-    vAlignContent?: 'top' | 'center' | 'bottom';
-    hAlignContent?: 'left' | 'center' | 'right';
-    marginLeft?: string | number;
-    marginTop?: string | number;
-    marginRight?: string | number;
-    marginBottom?: string | number;
-    grow?: boolean | number;
-    shrink?: boolean | number;
-    basis?: string | number;
-    wrap?: boolean;
-    height?: string | number;
-    width?: string | number;
-    className?: string;
-    style?: {
-        [key: string]: any;
-    };
-    [key: string]: any;
-};
+
+// listing all Div attributes apart from "wrap" because Div's wrap conflicts with FLexView' wrap
+type HTMLDivElementPropsKeys = "defaultChecked" | "defaultValue" | "suppressContentEditableWarning" | "accept" | "acceptCharset" | "accessKey" | "action" | "allowFullScreen" | "allowTransparency" | "alt" | "async" | "autoComplete" | "autoFocus" | "autoPlay" | "capture" | "cellPadding" | "cellSpacing" | "charSet" | "challenge" | "checked" | "classID" | "className" | "cols" | "colSpan" | "content" | "contentEditable" | "contextMenu" | "controls" | "coords" | "crossOrigin" | "data" | "dateTime" | "default" | "defer" | "dir" | "disabled" | "download" | "draggable" | "encType" | "form" | "formAction" | "formEncType" | "formMethod" | "formNoValidate" | "formTarget" | "frameBorder" | "headers" | "height" | "hidden" | "high" | "href" | "hrefLang" | "htmlFor" | "httpEquiv" | "id" | "inputMode" | "integrity" | "is" | "keyParams" | "keyType" | "kind" | "label" | "lang" | "list" | "loop" | "low" | "manifest" | "marginHeight" | "marginWidth" | "max" | "maxLength" | "media" | "mediaGroup" | "method" | "min" | "minLength" | "multiple" | "muted" | "name" | "nonce" | "noValidate" | "open" | "optimum" | "pattern" | "placeholder" | "playsInline" | "poster" | "preload" | "radioGroup" | "readOnly" | "rel" | "required" | "reversed" | "role" | "rows" | "rowSpan" | "sandbox" | "scope" | "scoped" | "scrolling" | "seamless" | "selected" | "shape" | "size" | "sizes" | "slot" | "span" | "spellCheck" | "src" | "srcDoc" | "srcLang" | "srcSet" | "start" | "step" | "style" | "summary" | "tabIndex" | "target" | "title" | "type" | "useMap" | "value" | "width" | "wmode" | "about" | "datatype" | "inlist" | "prefix" | "property" | "resource" | "typeof" | "vocab" | "autoCapitalize" | "autoCorrect" | "autoSave" | "color" | "itemProp" | "itemScope" | "itemType" | "itemID" | "itemRef" | "results" | "security" | "unselectable" | "children" | "dangerouslySetInnerHTML" | "onCopy" | "onCopyCapture" | "onCut" | "onCutCapture" | "onPaste" | "onPasteCapture" | "onCompositionEnd" | "onCompositionEndCapture" | "onCompositionStart" | "onCompositionStartCapture" | "onCompositionUpdate" | "onCompositionUpdateCapture" | "onFocus" | "onFocusCapture" | "onBlur" | "onBlurCapture" | "onChange" | "onChangeCapture" | "onInput" | "onInputCapture" | "onReset" | "onResetCapture" | "onSubmit" | "onSubmitCapture" | "onLoad" | "onLoadCapture" | "onError" | "onErrorCapture" | "onKeyDown" | "onKeyDownCapture" | "onKeyPress" | "onKeyPressCapture" | "onKeyUp" | "onKeyUpCapture" | "onAbort" | "onAbortCapture" | "onCanPlay" | "onCanPlayCapture" | "onCanPlayThrough" | "onCanPlayThroughCapture" | "onDurationChange" | "onDurationChangeCapture" | "onEmptied" | "onEmptiedCapture" | "onEncrypted" | "onEncryptedCapture" | "onEnded" | "onEndedCapture" | "onLoadedData" | "onLoadedDataCapture" | "onLoadedMetadata" | "onLoadedMetadataCapture" | "onLoadStart" | "onLoadStartCapture" | "onPause" | "onPauseCapture" | "onPlay" | "onPlayCapture" | "onPlaying" | "onPlayingCapture" | "onProgress" | "onProgressCapture" | "onRateChange" | "onRateChangeCapture" | "onSeeked" | "onSeekedCapture" | "onSeeking" | "onSeekingCapture" | "onStalled" | "onStalledCapture" | "onSuspend" | "onSuspendCapture" | "onTimeUpdate" | "onTimeUpdateCapture" | "onVolumeChange" | "onVolumeChangeCapture" | "onWaiting" | "onWaitingCapture" | "onClick" | "onClickCapture" | "onContextMenu" | "onContextMenuCapture" | "onDoubleClick" | "onDoubleClickCapture" | "onDrag" | "onDragCapture" | "onDragEnd" | "onDragEndCapture" | "onDragEnter" | "onDragEnterCapture" | "onDragExit" | "onDragExitCapture" | "onDragLeave" | "onDragLeaveCapture" | "onDragOver" | "onDragOverCapture" | "onDragStart" | "onDragStartCapture" | "onDrop" | "onDropCapture" | "onMouseDown" | "onMouseDownCapture" | "onMouseEnter" | "onMouseLeave" | "onMouseMove" | "onMouseMoveCapture" | "onMouseOut" | "onMouseOutCapture" | "onMouseOver" | "onMouseOverCapture" | "onMouseUp" | "onMouseUpCapture" | "onSelect" | "onSelectCapture" | "onTouchCancel" | "onTouchCancelCapture" | "onTouchEnd" | "onTouchEndCapture" | "onTouchMove" | "onTouchMoveCapture" | "onTouchStart" | "onTouchStartCapture" | "onScroll" | "onScrollCapture" | "onWheel" | "onWheelCapture" | "onAnimationStart" | "onAnimationStartCapture" | "onAnimationEnd" | "onAnimationEndCapture" | "onAnimationIteration" | "onAnimationIterationCapture" | "onTransitionEnd" | "onTransitionEndCapture" | "ref" | "key"
+
+export declare interface IProps extends Pick<React.HTMLProps<HTMLDivElement>, HTMLDivElementPropsKeys> {
+  children?: any;
+  column?: boolean;
+  vAlignContent?: 'top' | 'center' | 'bottom';
+  hAlignContent?: 'left' | 'center' | 'right';
+  marginLeft?: string | number;
+  marginTop?: string | number;
+  marginRight?: string | number;
+  marginBottom?: string | number;
+  grow?: boolean | number;
+  shrink?: boolean | number;
+  basis?: string | number;
+  wrap?: boolean;
+  height?: string | number;
+  width?: string | number;
+}
 /** React component to abstract over flexbox
  * @param children - flexView content
  * @param column - flex-direction: column
@@ -38,14 +37,14 @@ export declare type IProps = {
  * @param width - width property (for parent secondary axis)
  */
 export default class FlexView extends React.Component<IProps, void> {
-    componentDidMount(): void;
-    private logWarnings;
-    private getGrow;
-    private getShrink;
-    private getBasis;
-    private getFlexStyle;
-    private getStyle;
-    private getContentAlignmentClasses;
-    private getClasses;
-    render(): JSX.Element;
+  componentDidMount(): void;
+  private logWarnings;
+  private getGrow;
+  private getShrink;
+  private getBasis;
+  private getFlexStyle;
+  private getStyle;
+  private getContentAlignmentClasses;
+  private getClasses;
+  render(): JSX.Element;
 }


### PR DESCRIPTION
Closes #37

## Test Plan

### tests performed
- install locally on AlinityPRO
- pass `onClick='c'` -> error!
- pass `wrap={true}` -> happy
- pass `vAlignContent='uuu'` -> error!
- pass `ref={4}` -> error!

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
