### PR TITLE
Don't use void for State type parameter or React.Component

### DIFF
--- a/src/FlexView.tsx
+++ b/src/FlexView.tsx
@@ -51,7 +51,7 @@ export namespace FlexView {
 }
 
 /** A powerful React component to abstract over flexbox and create any layout on any browser */
-export default class FlexView extends React.Component<FlexView.Props, void> {
+export default class FlexView extends React.Component<FlexView.Props> {
 
   static propTypes = {
     children: PropTypes.node,


### PR DESCRIPTION
Using `void` causes an error with the most recent version of `@types/react`.

```
JSX element type 'FlexView' is not a constructor function for JSX elements.
  Types of property 'state' are incompatible.
    Type 'void' is not assignable to type 'Readonly<{}>'.
[tslint] unused expression, expected an assignment or function call (no-unused-expression)
```