### PR TITLE
drop dep on typelevel-ts by using recent TS lib types

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
     "lodash.omit": "^4.5.0",
     "lodash.pick": "^4.4.0",
     "lodash.some": "^4.6.0",
-    "prop-types": "^15.5.6",
-    "typelevel-ts": "^0.3.1"
+    "prop-types": "^15.5.6"
   },
   "devDependencies": {
     "@types/classnames": "2.2.3",

--- a/src/FlexView.tsx
+++ b/src/FlexView.tsx
@@ -3,7 +3,10 @@ import * as PropTypes from 'prop-types';
 import pick = require('lodash.pick');
 import omit = require('lodash.omit');
 import some = require('lodash.some');
-import { Overwrite, Omit } from 'typelevel-ts';
+
+export type Omit<O, K extends string> = Pick<O, Exclude<keyof O, K>>;
+
+export type Overwrite<O1, O2> = Pick<O1, Exclude<keyof O1, keyof O2>> & O2;
 
 declare var process: { env: { NODE_ENV: 'production' | 'development' } };
 


### PR DESCRIPTION
Should this be breaking? TS >= 2.8 is now required to use this lib in a TS project