### PR TITLE
#72: Remove lodash deps (closes #72)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,13 +37,11 @@
   },
   "homepage": "https://github.com/buildo/react-flexview",
   "dependencies": {
-    "lodash.omit": "^4.5.0",
     "prop-types": "^15.5.6"
   },
   "devDependencies": {
     "@types/classnames": "^2.2.3",
     "@types/jest": "^21.1.8",
-    "@types/lodash.omit": "^4.5.3",
     "@types/prop-types": "^15.5.2",
     "@types/react": "^16.0.25",
     "@types/react-dom": "^16.0.3",

--- a/package.json
+++ b/package.json
@@ -38,14 +38,12 @@
   "homepage": "https://github.com/buildo/react-flexview",
   "dependencies": {
     "lodash.omit": "^4.5.0",
-    "lodash.some": "^4.6.0",
     "prop-types": "^15.5.6"
   },
   "devDependencies": {
     "@types/classnames": "^2.2.3",
     "@types/jest": "^21.1.8",
     "@types/lodash.omit": "^4.5.3",
-    "@types/lodash.some": "^4.6.3",
     "@types/prop-types": "^15.5.2",
     "@types/react": "^16.0.25",
     "@types/react-dom": "^16.0.3",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "homepage": "https://github.com/buildo/react-flexview",
   "dependencies": {
     "lodash.omit": "^4.5.0",
-    "lodash.pick": "^4.4.0",
     "lodash.some": "^4.6.0",
     "prop-types": "^15.5.6"
   },
@@ -46,7 +45,6 @@
     "@types/classnames": "^2.2.3",
     "@types/jest": "^21.1.8",
     "@types/lodash.omit": "^4.5.3",
-    "@types/lodash.pick": "^4.4.3",
     "@types/lodash.some": "^4.6.3",
     "@types/prop-types": "^15.5.2",
     "@types/react": "^16.0.25",

--- a/src/FlexView.tsx
+++ b/src/FlexView.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import * as PropTypes from "prop-types";
-import pick = require("lodash.pick");
 import omit = require("lodash.omit");
 import some = require("lodash.some");
 
@@ -204,14 +203,14 @@ export class FlexView extends React.Component<FlexView.Props> {
   getStyle(): React.CSSProperties {
     const { column, wrap, vAlignContent, hAlignContent } = this.props;
 
-    const style = pick(this.props, [
-      "width",
-      "height",
-      "marginLeft",
-      "marginTop",
-      "marginRight",
-      "marginBottom"
-    ]);
+    const style = {
+      width: this.props.width,
+      height: this.props.height,
+      marginLeft: this.props.marginLeft,
+      marginTop: this.props.marginTop,
+      marginRight: this.props.marginRight,
+      marginBottom: this.props.marginBottom
+    };
 
     function alignPropToFlex(
       align: FlexView.Props["vAlignContent"] | FlexView.Props["hAlignContent"]

--- a/src/FlexView.tsx
+++ b/src/FlexView.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import * as PropTypes from "prop-types";
 import omit = require("lodash.omit");
-import some = require("lodash.some");
 
 export type Omit<O, K extends string> = Pick<O, Exclude<keyof O, K>>;
 
@@ -14,6 +13,11 @@ function warn(warning: string): void {
     console.warn(warning); // eslint-disable-line no-console
   }
 }
+
+function some(array: any[], predicate: (v: any) => boolean): boolean {
+  return array.filter(predicate).length > 0;
+}
+
 export namespace FlexView {
   export type Props = Overwrite<
     Omit<React.HTMLProps<HTMLDivElement>, "ref">,

--- a/src/FlexView.tsx
+++ b/src/FlexView.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import * as PropTypes from "prop-types";
-import omit = require("lodash.omit");
 
 export type Omit<O, K extends string> = Pick<O, Exclude<keyof O, K>>;
 
@@ -18,44 +17,45 @@ function some(array: any[], predicate: (v: any) => boolean): boolean {
   return array.filter(predicate).length > 0;
 }
 
+type DivProps = Omit<React.HTMLProps<HTMLDivElement>, "ref">;
+
+type FlexViewProps = {
+  /** FlexView content */
+  children?: React.ReactNode;
+  /** flex-direction: column */
+  column?: boolean;
+  /** align content vertically */
+  vAlignContent?: "top" | "center" | "bottom";
+  /** align content horizontally */
+  hAlignContent?: "left" | "center" | "right";
+  /** margin-left property ("auto" to align self right) */
+  marginLeft?: string | number;
+  /** margin-top property ("auto" to align self bottom) */
+  marginTop?: string | number;
+  /** margin-right property ("auto" to align self left) */
+  marginRight?: string | number;
+  /** margin-bottom property ("auto" to align self top) */
+  marginBottom?: string | number;
+  /** grow property (for parent primary axis) */
+  grow?: boolean | number;
+  /** flex-shrink property */
+  shrink?: boolean | number;
+  /** flex-basis property */
+  basis?: string | number;
+  /** wrap content */
+  wrap?: boolean;
+  /** height property (for parent secondary axis) */
+  height?: string | number;
+  /** width property (for parent secondary axis) */
+  width?: string | number;
+  /** class to pass to top level element of the component */
+  className?: string;
+  /** style object to pass to top level element of the component */
+  style?: React.CSSProperties;
+};
+
 export namespace FlexView {
-  export type Props = Overwrite<
-    Omit<React.HTMLProps<HTMLDivElement>, "ref">,
-    {
-      /** FlexView content */
-      children?: React.ReactNode;
-      /** flex-direction: column */
-      column?: boolean;
-      /** align content vertically */
-      vAlignContent?: "top" | "center" | "bottom";
-      /** align content horizontally */
-      hAlignContent?: "left" | "center" | "right";
-      /** margin-left property ("auto" to align self right) */
-      marginLeft?: string | number;
-      /** margin-top property ("auto" to align self bottom) */
-      marginTop?: string | number;
-      /** margin-right property ("auto" to align self left) */
-      marginRight?: string | number;
-      /** margin-bottom property ("auto" to align self top) */
-      marginBottom?: string | number;
-      /** grow property (for parent primary axis) */
-      grow?: boolean | number;
-      /** flex-shrink property */
-      shrink?: boolean | number;
-      /** flex-basis property */
-      basis?: string | number;
-      /** wrap content */
-      wrap?: boolean;
-      /** height property (for parent secondary axis) */
-      height?: string | number;
-      /** width property (for parent secondary axis) */
-      width?: string | number;
-      /** class to pass to top level element of the component */
-      className?: string;
-      /** style object to pass to top level element of the component */
-      style?: React.CSSProperties;
-    }
-  >;
+  export type Props = Overwrite<DivProps, FlexViewProps>;
 }
 
 /** A powerful React component to abstract over flexbox and create any layout on any browser */
@@ -252,11 +252,37 @@ export class FlexView extends React.Component<FlexView.Props> {
     };
   }
 
+  getDivProps(): DivProps & { [k in keyof FlexViewProps]?: never } {
+    const {
+      children,
+      className,
+      style,
+      column,
+      grow,
+      shrink,
+      basis,
+      wrap,
+      vAlignContent,
+      hAlignContent,
+      width,
+      height,
+      marginBottom,
+      marginTop,
+      marginLeft,
+      marginRight,
+      ...rest
+    } = this.props;
+
+    return rest;
+  }
+
   render() {
-    const style = this.getStyle();
-    const props = omit(this.props, Object.keys(FlexView.propTypes));
     return (
-      <div className={this.props.className} style={style} {...props}>
+      <div
+        className={this.props.className}
+        style={this.getStyle()}
+        {...this.getDivProps()}
+      >
         {this.props.children}
       </div>
     );

--- a/test/tests/__snapshots__/FlexView.test.tsx.snap
+++ b/test/tests/__snapshots__/FlexView.test.tsx.snap
@@ -11,9 +11,15 @@ exports[`FlexView renders correctly 1`] = `
       "flex": "1 1 auto",
       "flexDirection": "row",
       "flexWrap": "wrap",
+      "height": undefined,
       "justifyContent": "flex-end",
+      "marginBottom": undefined,
+      "marginLeft": undefined,
+      "marginRight": undefined,
+      "marginTop": undefined,
       "minHeight": 0,
       "minWidth": 0,
+      "width": undefined,
     }
   }
 >


### PR DESCRIPTION
Closes #72

## Test Plan

### tests performed

tested that all cases of `pick`, `omit` and `some` are still working:
- omit: flexview props are not being passed to `div` (react is not complaining)
- pick: marginTop/Left/Bottom/Right, width and height still works
- some: warnings still work

### tests not performed (domain coverage)

> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.
