### PR TITLE
slightly stricter children prop typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "@types/classnames": "^2.2.3",
     "@types/jest": "^21.1.8",
     "@types/prop-types": "^15.5.2",
-    "@types/react": "^16.0.25",
-    "@types/react-dom": "^16.0.3",
+    "@types/react": "^16.9.2",
+    "@types/react-dom": "^16.9.0",
     "babel-loader": "^7.1.2",
     "babel-preset-buildo": "^0.1.1",
     "file-loader": "^1.1.5",
@@ -59,7 +59,7 @@
     "smooth-release": "^8.0.0",
     "ts-jest": "^21.2.3",
     "ts-loader": "^2.3.3",
-    "typescript": "^2.9.2",
+    "typescript": "^3.6.3",
     "webpack": "3.5.5"
   },
   "jest": {

--- a/src/FlexView.tsx
+++ b/src/FlexView.tsx
@@ -1,6 +1,13 @@
 import * as React from "react";
 import * as PropTypes from "prop-types";
 
+type ReactText = string | number;
+type ReactChild = React.ReactElement<unknown> | ReactText;
+
+interface ChildrenArray extends Array<Children> {}
+type ReactFragment = ChildrenArray;
+type Children = ReactChild | ReactFragment | boolean | null | undefined;
+
 export type Omit<O, K extends string> = Pick<O, Exclude<keyof O, K>>;
 
 export type Overwrite<O1, O2> = Pick<O1, Exclude<keyof O1, keyof O2>> & O2;
@@ -21,7 +28,7 @@ type DivProps = Omit<React.HTMLProps<HTMLDivElement>, "ref">;
 
 type FlexViewProps = {
   /** FlexView content */
-  children?: React.ReactNode;
+  children?: Children;
   /** flex-direction: column */
   column?: boolean;
   /** align content vertically */


### PR DESCRIPTION
Small improvement wrt the "original" `ReactNode` (https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L186-L191) where we don't accept `{}`.

e.g. with this change, the following code does not compile:
```tsx
<FlexView>{some('a')}</FlexView>
```

Some additional background here: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/35622

tested on an internal project, doesn't seem to break anything