### PR TITLE
Allow customizing the underlying intrinsic element

### DIFF
--- a/src/FlexView.tsx
+++ b/src/FlexView.tsx
@@ -22,7 +22,7 @@ function some(array: any[], predicate: (v: any) => boolean): boolean {
   return array.filter(predicate).length > 0;
 }
 
-type DivProps = Omit<React.HTMLProps<HTMLDivElement>, "ref">;
+type ElementProps = Omit<React.HTMLProps<HTMLElement>, "ref">;
 
 type FlexViewProps = {
   /** FlexView content */
@@ -57,10 +57,12 @@ type FlexViewProps = {
   className?: string;
   /** style object to pass to top level element of the component */
   style?: React.CSSProperties;
+  /** native dom component to render. Defaults to div */
+  component?: React.ElementType;
 };
 
 export namespace FlexView {
-  export type Props = Overwrite<DivProps, FlexViewProps>;
+  export type Props = Overwrite<ElementProps, FlexViewProps>;
 }
 
 export class FlexViewInternal extends React.Component<
@@ -82,7 +84,8 @@ export class FlexViewInternal extends React.Component<
     height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     className: PropTypes.string,
-    style: PropTypes.object
+    style: PropTypes.object,
+    component: PropTypes.elementType
   };
 
   componentDidMount() {
@@ -258,7 +261,7 @@ export class FlexViewInternal extends React.Component<
     };
   }
 
-  getDivProps(): DivProps & { [k in keyof FlexViewProps]?: never } {
+  getElementProps(): ElementProps & { [k in keyof FlexViewProps]?: never } {
     const {
       children,
       className,
@@ -277,6 +280,7 @@ export class FlexViewInternal extends React.Component<
       marginLeft,
       marginRight,
       divRef,
+      component,
       ...rest
     } = this.props;
 
@@ -284,16 +288,13 @@ export class FlexViewInternal extends React.Component<
   }
 
   render() {
-    return (
-      <div
-        ref={this.props.divRef}
-        className={this.props.className}
-        style={this.getStyle()}
-        {...this.getDivProps()}
-      >
-        {this.props.children}
-      </div>
-    );
+    return React.createElement(this.props.component || "div", {
+      ref: this.props.divRef,
+      className: this.props.className,
+      style: this.getStyle(),
+      children: this.props.children,
+      ...this.getElementProps()
+    });
   }
 }
 

--- a/test/tests/FlexView.test.tsx
+++ b/test/tests/FlexView.test.tsx
@@ -14,6 +14,22 @@ describe("FlexView", () => {
     );
     expect(component).toMatchSnapshot();
   });
+
+  it("renders custom intrinsic elements", () => {
+    const component = renderer.create(
+      <FlexView
+        component="form"
+        vAlignContent="center"
+        hAlignContent="right"
+        grow
+        shrink
+        wrap
+      >
+        CONTENT
+      </FlexView>
+    );
+    expect(component).toMatchSnapshot();
+  });
 });
 
 describe("build", () => {

--- a/test/tests/__snapshots__/FlexView.test.tsx.snap
+++ b/test/tests/__snapshots__/FlexView.test.tsx.snap
@@ -27,6 +27,33 @@ exports[`FlexView renders correctly 1`] = `
 </div>
 `;
 
+exports[`FlexView renders custom native elements 1`] = `
+<form
+  className={undefined}
+  style={
+    Object {
+      "alignItems": "center",
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flex": "1 1 auto",
+      "flexDirection": "row",
+      "flexWrap": "wrap",
+      "height": undefined,
+      "justifyContent": "flex-end",
+      "marginBottom": undefined,
+      "marginLeft": undefined,
+      "marginRight": undefined,
+      "marginTop": undefined,
+      "minHeight": 0,
+      "minWidth": 0,
+      "width": undefined,
+    }
+  }
+>
+  CONTENT
+</form>
+`;
+
 exports[`build build script generates every needed file 1`] = `
 Array [
   "FlexView.d.ts",

--- a/test/tests/__snapshots__/FlexView.test.tsx.snap
+++ b/test/tests/__snapshots__/FlexView.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`FlexView renders correctly 1`] = `
 </div>
 `;
 
-exports[`FlexView renders custom native elements 1`] = `
+exports[`FlexView renders custom intrinsic elements 1`] = `
 <form
   className={undefined}
   style={


### PR DESCRIPTION
`FlexView` uses `div` as a default for the underlying component.

This PR allows changing the default to another intrinsic component. For example:

```tsx
<FlexView />
<FlexView component="form" />
```

will render

```tsx
<div ... />
<form ... />
```